### PR TITLE
[FIX] 채팅 리스트 화면 수정

### DIFF
--- a/src/components/chat/ChatBubble.jsx
+++ b/src/components/chat/ChatBubble.jsx
@@ -13,7 +13,7 @@ function Avatar({ initials = "" }) {
 }
 
 
-export default function ChatBubble({ msg, onToggleBookmark }) {
+export default function ChatBubble({ msg, onToggleBookmark, onImageClick, onFileClick }) {
  
   const isLeft = msg.side === "left";
   const type = msg.type || "text";
@@ -30,7 +30,7 @@ export default function ChatBubble({ msg, onToggleBookmark }) {
       )}
 
       {/* 내 대화 북마크 */}
-      {!isLeft && (
+      {!isLeft && type === "text" && (
         <div className="self-end mb-[1rem] mr-[0.5rem]">
           <button
             onClick={() => onToggleBookmark?.(msg.id)}
@@ -97,11 +97,55 @@ export default function ChatBubble({ msg, onToggleBookmark }) {
                         src={src}
                         alt={`uploaded-${idx}`}
                         className="w-full max-w-[10rem] rounded-[0.5rem] border border-[#DEE2E6]"
+                        onClick={() => onImageClick?.(src)} 
                       />
                     ))}          
                 </div>
               </div>
               )}
+
+              {type === "file" && msg.files && (
+                  <div
+                    className="relative max-w-[15rem] rounded-[1rem] pl-[1.25rem] pr-[1.25rem] pt-[0.875rem] pb-[0.875rem]"
+                  >
+                    <div className="flex flex-col gap-[0.5rem]">
+                      {msg.files.map((file, idx) => {
+                        const sizeKB =
+                          typeof file?.size === "number"
+                            ? `${(file.size / 1024).toFixed(1)} KB`
+                            : null;
+
+                        return (
+                          <button
+                            key={idx}
+                            type="button"
+                            onClick={() => onFileClick?.(file)}   // 🔹 클릭 시 다운로드
+                            className="flex text-left items-center gap-[0.5rem] bg-[#F2F4F8] rounded-[0.5rem] px-[0.75rem] py-[0.5rem]"
+                          >
+                            {/* 파일 아이콘 */}
+                            <div className="flex justify-center items-center w-[2rem] h-[2rem] rounded-[0.5rem] bg-white border border-[#DEE2E6]">
+                              <svg xmlns="http://www.w3.org/2000/svg" width="22" height="27" viewBox="0 0 22 27" fill="none">
+                                <path d="M10.6667 0V8.66667C10.6667 9.16384 10.8519 9.64319 11.1862 10.0112C11.5204 10.3793 11.9798 10.6096 12.4747 10.6573L12.6667 10.6667H21.3333V24C21.3335 24.6728 21.0795 25.3208 20.622 25.8141C20.1645 26.3074 19.5375 26.6095 18.8667 26.66L18.6667 26.6667H2.66667C1.9939 26.6669 1.34591 26.4128 0.852603 25.9553C0.359294 25.4979 0.0571246 24.8709 0.00666695 24.2L1.33691e-07 24V2.66667C-0.000212772 1.9939 0.253875 1.34591 0.711329 0.852603C1.16878 0.359294 1.79579 0.0571244 2.46667 0.00666682L2.66667 0H10.6667ZM13.3333 0.0573333C13.7645 0.148866 14.1663 0.345852 14.5027 0.630667L14.6667 0.781333L20.552 6.66667C20.8644 6.97882 21.0944 7.36367 21.2213 7.78667L21.2747 8H13.3333V0.0573333Z" fill="#FF7053"/>
+                              </svg>
+                            </div>
+
+                            {/* 파일 정보 */}
+                            <div className="flex flex-col min-w-0">
+                              <span className="text-[0.8125rem] text-[#191D1F] truncate max-w-[10rem]">
+                                {file?.name || `파일 ${idx + 1}`}
+                              </span>
+                              {sizeKB && (
+                                <span className="text-[0.6875rem] text-[#6C757D]">
+                                  {sizeKB}
+                                </span>
+                              )}
+                            </div>
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </div>
+                )}
           </div>
         </div>
 
@@ -118,7 +162,7 @@ export default function ChatBubble({ msg, onToggleBookmark }) {
       </div>
 
       {/* 상대 대화 북마크 */}
-      {isLeft && (
+      {isLeft && type === "text" && (
         <div className="self-end mb-[1rem] ml-[0.5rem]">
           <button
             onClick={() => onToggleBookmark?.(msg.id)}

--- a/src/components/chat/ChatInput.jsx
+++ b/src/components/chat/ChatInput.jsx
@@ -6,9 +6,10 @@ export default function ChatInput({ onSend, side = "right" }) {
 
   const [previewImages, setPreviewImages] = useState([]); // 미리보기 이미지 list
   const [showPreview, setShowPreview] = useState(false);
-
+  
   const cameraInputRef = React.useRef(null);
   const albumInputRef = React.useRef(null);
+  const fileInputRef = React.useRef(null);  
 
   const sendText = () => {
     const t = text.trim();
@@ -37,11 +38,27 @@ export default function ChatInput({ onSend, side = "right" }) {
     setShowPreview(true);
   };
 
+  // 파일 선택 처리
+  const handleFile = (e) => {
+    const files = Array.from(e.target.files);
+    if (!files.length) return;
+
+    // 부모에 File[] 전달
+    onSend(files, side, "file");
+
+    // 같은 파일 다시 선택 가능하도록 초기화
+    e.target.value = "";
+
+    // 시트 닫기
+    setOpen(false);
+  };
+
   // 미리보기 → 전송
   const sendImages = () => {
     onSend(previewImages, side, "image");
     setPreviewImages([]);
     setShowPreview(false);
+    setOpen(false);
   };
 
   // 미리보기 → 취소
@@ -69,6 +86,15 @@ export default function ChatInput({ onSend, side = "right" }) {
          style={{ display: "none" }}
          onChange={handleAlbum}
        />
+
+        <input
+          type="file"
+          ref={fileInputRef}
+          style={{ display: "none" }}
+          onChange={handleFile}
+          multiple // 여러 파일 전송을 허용
+        />
+
     <div className="flex items-center border-none border-none pt-[1rem] pl-[1.5rem] pr-[1.5rem] pb-[1rem] shadow-[0_-3px_4px_rgba(0,0,0,0.08)]">
       
 
@@ -119,9 +145,9 @@ export default function ChatInput({ onSend, side = "right" }) {
                   onClick={() => cameraInputRef.current.click()}
                 >
                   <svg xmlns="http://www.w3.org/2000/svg" width="27" height="24" viewBox="0 0 27 24" fill="none">
-                    <path d="M24 4H20.552L16.9427 0.390667C16.6927 0.140601 16.3536 7.55165e-05 16 0H10.6667C10.3131 7.55165e-05 9.97399 0.140601 9.724 0.390667L6.11467 4H2.66667C1.196 4 0 5.196 0 6.66667V21.3333C0 22.804 1.196 24 2.66667 24H24C25.4707 24 26.6667 22.804 26.6667 21.3333V6.66667C26.6667 5.196 25.4707 4 24 4ZM13.3333 20C9.72 20 6.66667 16.9467 6.66667 13.3333C6.66667 9.72 9.72 6.66667 13.3333 6.66667C16.9467 6.66667 20 9.72 20 13.3333C20 16.9467 16.9467 20 13.3333 20Z" fill="#FF7053">
-                    </path>
-                  </svg>                  
+                    <path d="M13.3333 9.33333C11.1653 9.33333 9.33333 11.1653 9.33333 13.3333C9.33333 15.5013 11.1653 17.3333 13.3333 17.3333C15.5013 17.3333 17.3333 15.5013 17.3333 13.3333C17.3333 11.1653 15.5013 9.33333 13.3333 9.33333Z" fill="#FF7053"/>
+                    <path d="M24 4H20.552L16.9427 0.390667C16.6927 0.140601 16.3536 7.55165e-05 16 0H10.6667C10.3131 7.55165e-05 9.97399 0.140601 9.724 0.390667L6.11467 4H2.66667C1.196 4 0 5.196 0 6.66667V21.3333C0 22.804 1.196 24 2.66667 24H24C25.4707 24 26.6667 22.804 26.6667 21.3333V6.66667C26.6667 5.196 25.4707 4 24 4ZM13.3333 20C9.72 20 6.66667 16.9467 6.66667 13.3333C6.66667 9.72 9.72 6.66667 13.3333 6.66667C16.9467 6.66667 20 9.72 20 13.3333C20 16.9467 16.9467 20 13.3333 20Z" fill="#FF7053"/>
+                  </svg>               
                 </button>
                 <span className="text-[#3B3D40] text-[0.75rem]">
                   카메라
@@ -147,6 +173,7 @@ export default function ChatInput({ onSend, side = "right" }) {
                 <button
                   type="file"
                   className="flex justify-center items-center bg-[#F2F4F8] w-[3rem] h-[3rem] rounded-full"
+                  onClick={() => fileInputRef.current?.click()} 
                 >
                   <svg xmlns="http://www.w3.org/2000/svg" width="22" height="27" viewBox="0 0 22 27" fill="none">
                     <path d="M10.6667 0V8.66667C10.6667 9.16384 10.8519 9.64319 11.1862 10.0112C11.5204 10.3793 11.9798 10.6096 12.4747 10.6573L12.6667 10.6667H21.3333V24C21.3335 24.6728 21.0795 25.3208 20.622 25.8141C20.1645 26.3074 19.5375 26.6095 18.8667 26.66L18.6667 26.6667H2.66667C1.9939 26.6669 1.34591 26.4128 0.852603 25.9553C0.359294 25.4979 0.0571246 24.8709 0.00666695 24.2L1.33691e-07 24V2.66667C-0.000212772 1.9939 0.253875 1.34591 0.711329 0.852603C1.16878 0.359294 1.79579 0.0571244 2.46667 0.00666682L2.66667 0H10.6667ZM13.3333 0.0573333C13.7645 0.148866 14.1663 0.345852 14.5027 0.630667L14.6667 0.781333L20.552 6.66667C20.8644 6.97882 21.0944 7.36367 21.2213 7.78667L21.2747 8H13.3333V0.0573333Z" fill="#FF7053"/>
@@ -162,8 +189,9 @@ export default function ChatInput({ onSend, side = "right" }) {
                   type="save"
                   className="flex justify-center items-center bg-[#F2F4F8] w-[3rem] h-[3rem] rounded-full"
                 >
-                  <svg xmlns="http://www.w3.org/2000/svg" width="20" height="25" viewBox="0 0 20 25" fill="none">
-                    <path d="M1 23.6667V1H18.3333V23.6667L9.66667 19.4847L1 23.6667Z" fill="#FF7053" stroke="#FF7053" stroke-width="2" stroke-linejoin="round"/>
+                  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="29" viewBox="0 0 24 29" fill="none">
+                    <path d="M5 27.6667V5H22.3333V27.6667L13.6667 23.4847L5 27.6667Z" fill="#FF7053"/>
+                    <path d="M18.3333 5V1H1V23.6667L5 21.6667M5 27.6667V5H22.3333V27.6667L13.6667 23.4847L5 27.6667Z" stroke="#FF7053" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                   </svg>
                 </button>
                 <span className="text-[#3B3D40] text-[0.75rem]">

--- a/src/components/chat/ChatListTopBar.jsx
+++ b/src/components/chat/ChatListTopBar.jsx
@@ -7,7 +7,7 @@ export default function ChatListTopBar({ title, isbutton }){
 
   return (
     <div className="top-0 z-20 bg-white shadow-[0_4px_5px_rgba(0,0,0,0.04)]">
-      <div className="w-full flex items-center justify-between pl-[1.5rem] pr-[1.5rem] pb-[1rem] pt-[1.5rem] box-border gap-[0.75rem]">
+      <div className="w-full flex items-center justify-between pl-[1.5rem] pr-[1.5rem] pb-[1.25rem] pt-[1.25rem] box-border gap-[0.75rem]">
         <span className="text-[1.1875rem] font-bold">
           {title}
         </span>

--- a/src/components/chat/ChatTopBar.jsx
+++ b/src/components/chat/ChatTopBar.jsx
@@ -1,8 +1,9 @@
 import React, { useState, useRef, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import TimerBanner from "./TimerBanner";
+import QuestionStrip from "./QuestionStrip";
 
-export default function TopBar({ startAt, endAt, onExpire }) {
+export default function TopBar({ startAt, endAt, onExpire, title}) {
   
   const navigate = useNavigate();
   const [searchOpen, setSearchOpen] = useState(false); 
@@ -29,7 +30,7 @@ export default function TopBar({ startAt, endAt, onExpire }) {
                 setSearchText(e.target.value);
                 props.onSearchChange(e.target.value);
               }}              
-              className="w-full rounded-[0.38rem] bg-[#F2F4F8] border-none outline-none text-[0.875rem] pl-[0.75rem] pr-[0.75rem]"
+              className="w-full rounded-[0.375rem] bg-[#F2F4F8] border-none outline-none text-[0.8rem] pt-[0.1rem] pb-[0.1rem] pl-[0.75rem] pr-[0.75rem]"
             />
           </div>
         )}
@@ -48,6 +49,7 @@ export default function TopBar({ startAt, endAt, onExpire }) {
         </div>
       </div>
       <TimerBanner startAt={startAt} endAt={endAt} onExpire={onExpire} />
+      <QuestionStrip title={title} />
     </div>
   );
 }

--- a/src/components/chat/ChatTopBar.jsx
+++ b/src/components/chat/ChatTopBar.jsx
@@ -9,15 +9,9 @@ export default function TopBar({ startAt, endAt, onExpire }) {
   const [searchText, setSearchText] = useState(""); 
   const inputRef = useRef(null);
 
-  useEffect(() => {
-    if (searchOpen && inputRef.current) {
-      inputRef.current.focus();
-    }
-  }, [searchOpen]);
-
   return (
-    <div>
-      <div className="w-full flex items-center justify-between pl-[1.5rem] pr-[1.5rem] pb-[1rem] pt-[1rem]">
+    <div className="fixed-0">
+      <div className="w-full flex items-center justify-between pl-[1.5rem] pr-[1.5rem] pb-[1.25rem] pt-[1.25rem]">
 
         <button aria-label="뒤로가기" className="border-none outline-none" onClick={() => navigate(-1)}>
           <svg xmlns="http://www.w3.org/2000/svg" width="10" height="16" viewBox="0 0 10 16" fill="none">

--- a/src/components/chat/QuestionStrip.jsx
+++ b/src/components/chat/QuestionStrip.jsx
@@ -7,8 +7,7 @@ export default function QuestionStrip({ title = "" }) {
   return (
     
     <div className={
-          "bg-[#FFEEEA] min-h-[2.5625rem] flex items-start justify-center pl-[1rem] pr-[1rem] pt-[0.625rem] pb-[0.625rem] fixed left-0 right-0 z-20" 
-          // (expanded ? "fixed left-0 right-0 z-20" : "relative")
+          "w-full bg-[#FFEEEA] min-h-[2.5625rem] flex items-start justify-center pl-[1rem] pr-[1rem] pt-[0.625rem] pb-[0.625rem] fixed left-0 right-0 z-10" 
         }>
       
       <div className="flex self-start items-center justify-center w-[2.0625rem] h-[1.3125rem] rounded-[0.25rem] bg-[#FA502E]">

--- a/src/components/contents/contentTopBar.jsx
+++ b/src/components/contents/contentTopBar.jsx
@@ -7,7 +7,7 @@ export default function ContentTopBar({ title, isbutton }){
 
   return (
     <div className="top-0 z-20 bg-white shadow-[0_4px_5px_rgba(0,0,0,0.04)]">
-      <div className="w-full flex items-center justify-start pl-[1.5rem] pr-[1.5rem] pb-[1rem] pt-[1.5rem] box-border gap-[0.75rem]">
+      <div className="w-full flex items-center justify-start pl-[1.5rem] pr-[1.5rem] pb-[1.25rem] pt-[1.25rem] box-border gap-[0.75rem]">
 
         <button 
           aria-label="뒤로가기" 

--- a/src/components/question/QuestionTopBar.jsx
+++ b/src/components/question/QuestionTopBar.jsx
@@ -8,7 +8,7 @@ export default function QuestionTopBar({ title,   onSubmit, canSubmit }) {
   
 
   return (  
-  <div className="w-full flex items-center justify-between pl-[1.5rem] pr-[1.5rem] pt-[1.5rem] pb-[1rem] box-border shadow-[0_4px_5px_rgba(0,0,0,0.04)]">
+  <div className="w-full flex items-center justify-between pl-[1.5rem] pr-[1.5rem] pt-[1.25rem] pb-[1.25rem] box-border shadow-[0_4px_5px_rgba(0,0,0,0.04)]">
 
     <button type="button" className="bg-[#FFFFFF] border-0" onClick={() => navigate(-1)}>
       <svg xmlns="http://www.w3.org/2000/svg" width="9" height="15" viewBox="0 0 9 15" fill="none">

--- a/src/pages/ChatListPage.jsx
+++ b/src/pages/ChatListPage.jsx
@@ -120,7 +120,7 @@ export default function ChatListPage() {
                 
                 <div className="flex items-center gap-[0.5rem]">
 
-                  <span className="text-[0.875rem] text-[#3B3D40]">
+                  <span className="text-[0.875rem] text-[#3B3D40] line-clamp-1">
                     {item.title}
                   </span>
 
@@ -151,7 +151,7 @@ export default function ChatListPage() {
                 )}
 
                 {tab === "past" && (
-                  <p className="text-[0.75rem] text-[#B5BBC1]">
+                  <p className="text-[0.75rem] text-[#B5BBC1] line-clamp-1">
                     {item.question}
                   </p>
                 )}


### PR DESCRIPTION
<!-- PR 이름은 '[컨벤션] 기능이름' 으로 통일해주세요.
 ex. [FEAT] searchPublicCourse -->

### Issue Number

close: #20 

### 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 채팅 목록 화면의 이전 채팅에서 문장이 길어질경우 1줄만 출력되고 나머지는 생략되도록 수정하였습니다.
- [x] TopBar의 상단, 하당 padding을 1.25rem으로 통일하였습니다.
- [x] 채팅 입력에서의 카메라 아이콘과 저장 아이콘을 수정하였습니다.
- [x] 채팅에서 파일 전송이 가능하도록 수정하였습니다.
- [x] 채팅에서 사진 전송이 일어난 경우 사진을 크게 볼 수 있도록 수정하였습니다.
- [x] 파일 전송이 일어난 경우 파일을 저장할 수 있도록 수정하였습니다.

### 변경사항

- 의존성 목록

### PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점
- TopBar 통일을 위해 전체 Topbar component 역시 수정하였습니다.


### Checklist

> PR 등록 전 확인할 점

- [ ] description에 PR에 대해 구체적으로 설명했나요?
