### PR TITLE
[FEAT] 전역 로그인 상태 기반 소켓 통신 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,6 @@
-import React from "react";
 import "./index.css";
 import { BrowserRouter as Router, Routes, Route, Navigate } from "react-router-dom";
+import React, { useState } from "react";
 import ContentSearchResultPage from "./pages/content/ContentSearchResultPage";
 import ContentSearchPage from "./pages/content/ContentSearchPage";
 import ContentRegisterPage from "./pages/content/ContentRegisterPage"
@@ -28,14 +28,18 @@ import ProfileEditScreen from "./pages/mypage/ProfileEditScreen";
 import ChatStartPopup from "./components/ChatStartPopup";
 import FriendProfileScreen from "./pages/friend/FriendProfileScreen";
 import FriendRequestScreen from "./pages/friend/FriendRequestScreen";
+import AuthContext from "./context/AuthContext";
 
 export default function App() {
   
   const height = window.innerHeight;
-  const isLoggedIn = !!localStorage.getItem("accessToken");
+  const [isLoggedIn, setIsLoggedIn] = useState(
+    !!localStorage.getItem("accessToken")
+  );
 
   return (
     <>
+    <AuthContext.Provider value={{ isLoggedIn, setIsLoggedIn }}>
     <NotificationProvider> {/* ✅ 전역 알림 상태 감싸기 */}
       <div className="flex justify-center items-center bg-white">
         <div className="min-w-[350px] max-w-[500px] w-full h-[100vh] bg-white shadow-md border border-gray-200">
@@ -74,6 +78,7 @@ export default function App() {
         </div>
       </div>
     </NotificationProvider>
+    </AuthContext.Provider>
     </>
   );
 }

--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -1,0 +1,9 @@
+// src/context/AuthContext.js
+import React, { createContext } from "react";
+
+const AuthContext = createContext({
+  isLoggedIn: false,
+  setIsLoggedIn: () => {},
+});
+
+export default AuthContext;

--- a/src/pages/login/LoginScreen.jsx
+++ b/src/pages/login/LoginScreen.jsx
@@ -1,17 +1,23 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useContext } from "react";
 import axios from "axios";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { login, kakaoLogin } from "../../lib/loginService";
 import { initSocket } from "../../lib/socket";
+import AuthContext from "../../context/AuthContext";
+
 
 export default function LoginScreen() {
   
   const navigate = useNavigate(); 
   const [error, setError] = useState(""); 
   const [searchParams] = useSearchParams(); // query parameters
+  
+  const { setIsLoggedIn } = useContext(AuthContext);
+
   const kakaoCode = searchParams.get("code"); // kakao 인가코드
   const KAKAO_REST_API_KEY = import.meta.env.VITE_KAKAO_REST_API_KEY;
   const KAKAO_REDIRECT_URI = import.meta.env.VITE_KAKAO_REDIRECT_URI;
+
 
   const extractToken = (authHeader) => {
     if (!authHeader) return null;
@@ -59,6 +65,7 @@ export default function LoginScreen() {
         if(token) {
           localStorage.setItem("accessToken", token);
           initSocket();
+          setIsLoggedIn(true);
         }
 
         navigate("/main", { replace: true });
@@ -110,6 +117,7 @@ export default function LoginScreen() {
       if (token) {
         localStorage.setItem("accessToken", token);
         initSocket();
+        setIsLoggedIn(true);
       }
 
       navigate("/main", { replace: true });


### PR DESCRIPTION
<!-- PR 이름은 '[컨벤션] 기능이름' 으로 통일해주세요.
 ex. [FEAT] searchPublicCourse -->

### Issue Number

close: #30 

### 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 로그인 여부를 전역적으로 관리하도록 수정하였습니다.
- [x] 로그인 상태를 기반으로 채팅 참여 알림이 뜰 수 있도록 개선하였습니다.


### PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 기존에는 최초 로그인 시에, 로그인 직후 로컬 스토리지에 토큰을 저장하더라도 로그인 여부를 useState로 관리하지 않아 소켓 connection이 시작되지 않는 문제가 있었습니다. 이를 전역 로그인 상태 여부 태그에 저장하여 로그인 여부에 따라 connection과 join room을 listen할 수 있도록 개선하였습니다.

### Checklist

> PR 등록 전 확인할 점

- [ ] description에 PR에 대해 구체적으로 설명했나요?
